### PR TITLE
Release version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.0.1 - 2022-01-20
+## 1.0.0 - 2022-12-15
+
+- Add appraisal, fasterer and reek [#19](https://github.com/bambooengineering/que-unique/pull/19)
+
+## 0.1.1 - 2022-01-20
 
 - Expand gemspec versions to include Rails 7 [#2](https://github.com/bambooengineering/que-unique/pull/2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    que-unique (0.1.1)
+    que-unique (1.0.0)
       activerecord (> 4.0, < 8.0)
       que (>= 0.14, < 3.0.0)
 

--- a/gemfiles/que_0_14.gemfile.lock
+++ b/gemfiles/que_0_14.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-unique (0.1.1)
+    que-unique (1.0.0)
       activerecord (> 4.0, < 8.0)
       que (>= 0.14, < 3.0.0)
 

--- a/gemfiles/que_1_x.gemfile.lock
+++ b/gemfiles/que_1_x.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-unique (0.1.1)
+    que-unique (1.0.0)
       activerecord (> 4.0, < 8.0)
       que (>= 0.14, < 3.0.0)
 

--- a/gemfiles/que_2_x.gemfile.lock
+++ b/gemfiles/que_2_x.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-unique (0.1.1)
+    que-unique (1.0.0)
       activerecord (> 4.0, < 8.0)
       que (>= 0.14, < 3.0.0)
 

--- a/lib/que/unique/version.rb
+++ b/lib/que/unique/version.rb
@@ -2,6 +2,6 @@
 
 module Que
   module Unique
-    VERSION = "0.1.1"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
We are going to a 1.x major as `que-unique` has been used successfully for many years and is production ready.